### PR TITLE
Default the receive pattern to the identity function

### DIFF
--- a/examples/http.js
+++ b/examples/http.js
@@ -10,7 +10,7 @@ const { take } = require('./_util')
 // worker
 async function worker(i) {
   while (1) {
-    const url = await this.receive(url => url)
+    const url = await this.receive()
     if (url === null) break
 
     console.log('[%d]: GET %s', i, url)
@@ -31,7 +31,7 @@ const lb = spawn(async function() {
   let reqs = 0
 
   while (1) {
-    const url = await this.receive(url => url)
+    const url = await this.receive()
     if (url === null) {
       workers.forEach(w => w.send(null))
       break

--- a/examples/query.js
+++ b/examples/query.js
@@ -17,7 +17,7 @@ function asyncQuery(queryDef) {
 const main = spawn(async function() {
   const queries = take(5)
     .map(i => asyncQuery(`query ${i}`))
-    .map(() => () => this.receive(a => a))
+    .map(() => () => this.receive())
 
   const results = await all(queries)
   console.log(results)

--- a/lib/actor.js
+++ b/lib/actor.js
@@ -34,7 +34,7 @@ module.exports = class Actor {
    * This is outlined on page 140 of "Elixir in Action".
    */
 
-  receive(pattern /*: (mixed) => mixed */) {
+  receive(pattern /*: (mixed) => mixed */ = (msg => msg)) {
     const b = new Blocked
 
     this.receiving = () => {

--- a/test/index.js
+++ b/test/index.js
@@ -68,6 +68,18 @@ describe('send and receive', function() {
     assert.equal(await pid, "is it me you're looking for")
   })
 
+  it('defaults receive pattern to the identity function', async function() {
+    spawn(function() {
+      pid.send('hello')
+    })
+
+    const pid = spawn(async function() {
+      return await this.receive();
+    })
+
+    assert.equal(await pid, "hello")
+  })
+
   it('returns a rejected Promise on receive error', async function() {
     let expect = 0
 


### PR DESCRIPTION
Love this project! I dig Elixir and this has a lot of potential.

One small thing I thought would make it better is to default the receive pattern to be the identity function. This allows a process to receive a message without doing any processing on it first, and avoids the need to pass in a function at all in this use case.